### PR TITLE
Support for kubelet parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,8 +59,8 @@ resource "azurerm_kubernetes_cluster" "main" {
     for_each = var.enable_auto_scaling == true ? [] : ["default_node_pool_manually_scaled"]
     content {
       kubelet_config {
-        container_log_max_line     = var.kubelet_log_max_line
-        container_log_max_size_mb  = var.kubelet_log_max_size_mb
+        container_log_max_line    = var.kubelet_log_max_line
+        container_log_max_size_mb = var.kubelet_log_max_size_mb
       }
       name                         = var.node_pool_name
       node_count                   = var.node_count
@@ -82,8 +82,8 @@ resource "azurerm_kubernetes_cluster" "main" {
     for_each = var.enable_auto_scaling == true ? ["default_node_pool_auto_scaled"] : []
     content {
       kubelet_config {
-        container_log_max_line     = var.kubelet_log_max_line
-        container_log_max_size_mb  = var.kubelet_log_max_size_mb
+        container_log_max_line    = var.kubelet_log_max_line
+        container_log_max_size_mb = var.kubelet_log_max_size_mb
       }
       name                         = var.node_pool_name
       vm_size                      = var.default_vm_size

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,10 @@ resource "azurerm_kubernetes_cluster" "main" {
   dynamic "default_node_pool" {
     for_each = var.enable_auto_scaling == true ? [] : ["default_node_pool_manually_scaled"]
     content {
+      kubelet_config {
+        container_log_max_line     = var.kubelet_log_max_line
+        container_log_max_size_mb  = var.kubelet_log_max_size_mb
+      }
       name                         = var.node_pool_name
       node_count                   = var.node_count
       vm_size                      = var.default_vm_size
@@ -77,6 +81,10 @@ resource "azurerm_kubernetes_cluster" "main" {
   dynamic "default_node_pool" {
     for_each = var.enable_auto_scaling == true ? ["default_node_pool_auto_scaled"] : []
     content {
+      kubelet_config {
+        container_log_max_line     = var.kubelet_log_max_line
+        container_log_max_size_mb  = var.kubelet_log_max_size_mb
+      }
       name                         = var.node_pool_name
       vm_size                      = var.default_vm_size
       os_disk_size_gb              = var.os_disk_size_gb

--- a/variables.tf
+++ b/variables.tf
@@ -330,3 +330,15 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "kubelet_log_max_line" {
+  description = "Kubelet config: maximum number of container log files that can be present for a container"
+  type        = number
+  default     = 2
+}
+
+variable "kubelet_log_max_size_mb" {
+  description = "Kubelet config: Specifies the maximum size in MB of container log file before it is rotated"
+  type        = number
+  default     = 10
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.82.0"
+      version = "~> 2.89.0"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
# SUMMARY
Add hability to configure kubelet parameters

## ADDITIONAL INFORMATION
Example of options:

```
module "aks" {
  source                    = "github.com/visma-raet/terraform-azurerm-kubernetes"
  ...
  ...
  oms_agent_enabled         = false
  kubelet_log_max_line      = 16
  kubelet_log_max_size_mb   = 1024
}
```
